### PR TITLE
feat(ci): use trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,11 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token
@@ -25,7 +30,8 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '25'
+          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
       - run: npm run build
@@ -34,7 +40,7 @@ jobs:
 
       - run: npx semantic-release
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - run: |
           git status
           git add -A

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.8",
       "license": "ISC",
       "dependencies": {
-        "@semantic-release/npm": "^13.0.0",
+        "@semantic-release/npm": "^13.1.0",
         "commander": "^14.0.0",
         "dotenv": "^16.4.5"
       },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "typescript": "^5.4.2"
   },
   "dependencies": {
-    "@semantic-release/npm": "^13.0.0",
+    "@semantic-release/npm": "^13.1.0",
     "commander": "^14.0.0",
     "dotenv": "^16.4.5"
   }


### PR DESCRIPTION
:magic_wand: :sparkles:

## Summary
- Add id-token: write permission to enable OIDC token generation
- Add contents: write, issues: write, pull-requests: write permissions for semantic-release
- Update node-version from 22 to 25 for npm 11 OIDC support
- Add registry-url to setup-node for OIDC authentication
- Remove NPM_TOKEN environment variable (replaced by OIDC)
- Upgrade @semantic-release/npm from ^13.0.0 to ^13.1.0 for OIDC support

## Why this change
npm trusted publishing with OIDC eliminates the need for long-lived NPM_TOKEN secrets. OIDC uses short-lived, workflow-specific credentials that are more secure. According to npm documentation, trusted publishing is the recommended approach for GitHub Actions.

References:
- https://docs.npmjs.com/trusted-publishers/
- https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions

- close #292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime used in build and deployment workflows.
  * Improved CI workflow permissions and registry configuration for package publishing.
  * Upgraded semantic-release tooling to the latest minor version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->