### PR TITLE
feat(ci): use trusted publishing

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,7 +16,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 19
+          node-version: 24
       - run: git pull
       - run: npm ci
       - run: npm run fmt && git --no-pager diff

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '25'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - name: Install dependencies
         run: npm ci
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "bin/index.js",
   "scripts": {
     "prebuild": "npm run doctor",
-    "doctor:node-version": "check-node-version --node 20 --npx 10 --npm 10",
+    "doctor:node-version": "check-node-version --node 24 --npx 11 --npm 11",
     "doctor": "npm run doctor:node-version",
     "prettier": "prettier --write '**/*'",
     "lint": "eslint src",
@@ -27,6 +27,9 @@
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/HiromiShikata/template-typescript-npm-cli/issues"
+  },
+  "publishConfig": {
+    "provenance": true
   },
   "release": {
     "plugins": [


### PR DESCRIPTION
:magic_wand: :sparkles:

## Summary
- Add provenance: true to @semantic-release/npm plugin for OIDC authentication
- Update Node.js version from 20/25 to 24 across all workflows for npm 11 support
- Update doctor:node-version check to require Node 24 and npm 11

## Why this change
npm trusted publishing with OIDC eliminates the need for long-lived NPM_TOKEN secrets. OIDC uses short-lived, workflow-specific credentials that are more secure. According to npm documentation, trusted publishing is the recommended approach for GitHub Actions.

References:
- https://docs.npmjs.com/trusted-publishers/
- https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions

- close #308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime to v24 across CI workflows and local tool checks; local script requirements updated to Node 24, npx 11, npm 11.
  * Enabled package publish provenance for stronger release integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->